### PR TITLE
OpenWrt: add rockchip-armv8  target to build pipeline

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -163,6 +163,7 @@ jobs:
         branch:
           - openwrt-23.05
         arch:
+          - rockchip-armv8
           - aarch64_cortex-a53
           - aarch64_cortex-a72
           - aarch64_generic


### PR DESCRIPTION
Adds support for FriendlyARM NanoPi R2S
https://openwrt.org/toh/friendlyarm/nanopi_r2s

Successfully tested on Github Actions https://github.com/JiLiZART/youtubeUnblock/actions/runs/11244475252/job/31263367164

Also tested on my NanoPi R2S

Install 
```
Installing youtubeUnblock (1.0.0-603f91b-octeontx-1) to root...
Installing liblua5.1.5 (5.1.5-11) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/base/liblua5.1.5_5.1.5-11_aarch64_generic.ipk
Installing lua (5.1.5-11) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/base/lua_5.1.5-11_aarch64_generic.ipk
Installing luci-lib-nixio (git-24.034.54875-21210dc) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/luci-lib-nixio_git-24.034.54875-21210dc_aarch64_generic.ipk
Installing luci-lib-ip (git-23.311.79290-c2a887e) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/luci-lib-ip_git-23.311.79290-c2a887e_aarch64_generic.ipk
Installing luci-lib-jsonc (git-23.298.74571-62eb535) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/luci-lib-jsonc_git-23.298.74571-62eb535_aarch64_generic.ipk
Installing liblucihttp-lua (2023-03-15-9b5b683f-1) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/liblucihttp-lua_2023-03-15-9b5b683f-1_aarch64_generic.ipk
Installing luci-lib-base (git-22.308.54612-9118452) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/luci-lib-base_git-22.308.54612-9118452_all.ipk
Installing libubus-lua (2023-06-05-f787c97b-1) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/base/libubus-lua_2023-06-05-f787c97b-1_aarch64_generic.ipk
Installing ucode-mod-lua (1) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/ucode-mod-lua_1_aarch64_generic.ipk
Installing luci-lua-runtime (git-23.233.52805-dae2684) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/luci-lua-runtime_git-23.233.52805-dae2684_aarch64_generic.ipk
Installing luci-compat (git-24.086.45108-51aee90) to root...
Downloading https://downloads.openwrt.org/releases/23.05.4/packages/aarch64_generic/luci/luci-compat_git-24.086.45108-51aee90_all.ipk
Configuring liblua5.1.5.
Configuring lua.
Configuring luci-lib-nixio.
Configuring luci-lib-ip.
Configuring luci-lib-jsonc.
Configuring liblucihttp-lua.
Configuring luci-lib-base.
Configuring libubus-lua.
Configuring ucode-mod-lua.
Configuring luci-lua-runtime.
Configuring luci-compat.
Configuring youtubeUnblock.
```

And work logs 

```
e Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: Queue 537 started
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: IPv6 is enabled
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: GSO is enabled
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: Past seq faking strategy will be used
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: Fragmentation Client Hello will be reversed
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: Fake SNI will be sent before each target client hello
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: Using TCP segmentation
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]:
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: Bypasses deep packet inspection systems that relies on SNI
Tue Oct  8 22:43:47 2024 daemon.info youtubeUnblock[4375]: youtubeUnblock
```