### PR TITLE
Move workflow binaries builds to docker instead of cache

### DIFF
--- a/.github/builder_containers/README.md
+++ b/.github/builder_containers/README.md
@@ -1,0 +1,1 @@
+This directory contains dockerfiles for large docker containers. This allows not to rebuild binaries every build and not to utilize cache.

--- a/.github/builder_containers/entware-aarch64-3.10.Dockerfile
+++ b/.github/builder_containers/entware-aarch64-3.10.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/aarch64-3.10.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/entware-armv7-2.6.Dockerfile
+++ b/.github/builder_containers/entware-armv7-2.6.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git -b k2.6
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/armv7-2.6.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/entware-armv7-3.2.Dockerfile
+++ b/.github/builder_containers/entware-armv7-3.2.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/armv7-3.2.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/entware-mips-3.4.Dockerfile
+++ b/.github/builder_containers/entware-mips-3.4.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/mips-3.4.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/entware-mipsel-3.4.Dockerfile
+++ b/.github/builder_containers/entware-mipsel-3.4.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/mipsel-3.4.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/entware-x64-3.2.Dockerfile
+++ b/.github/builder_containers/entware-x64-3.2.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/x64-3.2.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/entware-x86-2.6.Dockerfile
+++ b/.github/builder_containers/entware-x86-2.6.Dockerfile
@@ -1,0 +1,6 @@
+FROM waujito/entware_builder
+RUN git clone --depth 1 https://github.com/Entware/Entware.git -b k2.6
+WORKDIR /home/me/Entware
+RUN make package/symlinks
+RUN cp -v configs/x86-2.6.config .config
+RUN make -j$(nproc) toolchain/install

--- a/.github/builder_containers/kernel-3.0.101.Dockerfile
+++ b/.github/builder_containers/kernel-3.0.101.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v3.x/linux-3.0.101.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/builder_containers/kernel-3.10.108.Dockerfile
+++ b/.github/builder_containers/kernel-3.10.108.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:16.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v3.x/linux-3.10.108.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/builder_containers/kernel-4.19.322.Dockerfile
+++ b/.github/builder_containers/kernel-4.19.322.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.322.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/builder_containers/kernel-4.4.302.Dockerfile
+++ b/.github/builder_containers/kernel-4.4.302.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.4.302.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/builder_containers/kernel-5.15.167.Dockerfile
+++ b/.github/builder_containers/kernel-5.15.167.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.167.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/builder_containers/kernel-5.4.284.Dockerfile
+++ b/.github/builder_containers/kernel-5.4.284.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.4.284.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/builder_containers/kernel-6.6.52.Dockerfile
+++ b/.github/builder_containers/kernel-6.6.52.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev wget
+
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.6.52.tar.xz -O kernel.tar.xz
+RUN tar -xf kernel.tar.xz
+RUN rm -f kernel.tar.xz
+RUN /bin/bash -c "mv linux-* linux"
+
+WORKDIR /linux
+RUN make defconfig
+RUN make -j$(nproc)

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -10,6 +10,7 @@ on:
       - 'LICENSE'
       - 'README.md'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   prepare:
@@ -309,58 +310,12 @@ jobs:
           - mips-3.4
           - mipsel-3.4
           - x64-3.2
-        include:
-          - arch: armv7-2.6
-            k26: true
-          - arch: x86-2.6
-            k26: true
+          - x86-2.6
+          - armv7-2.6
+    container:
+      image: waujito/entware_builder:${{ matrix.arch }}
+      options: --user root
     steps:
-      - name: Set up Entware docker container
-        run: |
-          git clone --depth 1 https://github.com/Entware/docker.git
-          docker build docker --pull --tag builder
-          docker volume create entware-home
-
-      - name: Restore Entware from cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/entware
-          key: entware-${{ matrix.arch }}
-
-      - name: Load Entware from cache
-        if: steps.cache-restore.outputs.cache-hit == 'true'
-        run: |
-          docker run --rm --mount source=entware-home,target=/backup_vol -v ~/entware:/backup ubuntu tar -xf /backup/entware.tar -C /backup_vol
-          docker run --rm --mount source=entware-home,target=/home/me -w /home/me ubuntu bash -c 'cp -r ./backup_vol/* ./'
-          docker run --rm --mount source=entware-home,target=/home/me -w /home/me ubuntu bash -c 'chown -R 1000:1000 ./* ./'
-
-      - name: Obtain Entware
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' &&  ! matrix.k26 }}
-        run: |
-          docker run --rm -i --mount source=entware-home,target=/home/me -w /home/me --name builder builder git clone --depth 1 https://github.com/Entware/Entware.git
-
-      - name: Obtain Entware k2.6
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && matrix.k26 }}
-        run: |
-          docker run --rm -i --mount source=entware-home,target=/home/me -w /home/me --name builder builder git clone --depth 1 https://github.com/Entware/Entware.git -b k2.6
-
-      - name: Build Entware 
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          docker run --rm -i --mount source=entware-home,target=/home/me -w /home/me/Entware --name builder builder make package/symlinks
-          docker run --rm -i --mount source=entware-home,target=/home/me -w /home/me/Entware --name builder builder cp -v configs/${{ matrix.arch }}.config .config
-          docker run --rm -i --mount source=entware-home,target=/home/me -w /home/me/Entware --name builder builder make -j$(nproc) toolchain/install
-          docker run --rm --mount source=entware-home,target=/backup_vol -v ~/entware:/backup ubuntu tar -cf /backup/entware.tar /backup_vol
-
-      - name: Save Entware to cache
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: ~/entware
-          key: entware-${{ matrix.arch }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -376,34 +331,27 @@ jobs:
 
       - name: Build packages
         id: build
-        run: |
-          echo "src-link youtubeUnblock /youtubeUnblock" | docker run --rm -i --mount source=entware-home,target=/home/me -v $GITHUB_WORKSPACE:/youtubeUnblock -w /home/me/Entware --name builder builder tee -a feeds.conf
-          docker run --rm -i --mount source=entware-home,target=/home/me -v $GITHUB_WORKSPACE:/youtubeUnblock -w /home/me/Entware --name builder builder ./scripts/feeds update youtubeUnblock
-          docker run --rm -i --mount source=entware-home,target=/home/me -v $GITHUB_WORKSPACE:/youtubeUnblock -w /home/me/Entware --name builder builder ./scripts/feeds install -a -p youtubeUnblock
-          echo "CONFIG_PACKAGE_youtubeUnblock=m" | docker run --rm -i --mount source=entware-home,target=/home/me -v $GITHUB_WORKSPACE:/youtubeUnblock -w /home/me/Entware --name builder builder tee -a .config
-          docker run --rm -i --mount source=entware-home,target=/home/me -v $GITHUB_WORKSPACE:/youtubeUnblock -w /home/me/Entware --name builder builder make package/youtubeUnblock/compile V=s
-
-      - name: Extract packages
-        if: steps.build.outcome == 'success'
-        shell: bash
+        working-directory: /home/me/Entware
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           RELEASE: ${{ needs.prepare.outputs.release }}
           SHA: ${{ needs.prepare.outputs.sha }}
         run: |
-          mkdir output
-          docker run --rm --user root -i --mount source=entware-home,target=/home/me -v $(pwd):/target -w /home/me/Entware --name builder builder find ./bin -type f -name 'youtubeUnblock*.ipk' -exec cp -v {} /target/output \;
-          rm -rf youtubeUnblock || true
-          mkdir youtubeUnblock
-          bash -c "cp -r ./output/* youtubeUnblock"
-          tar -czvf youtubeUnblock-$VERSION-$RELEASE-$SHA-${{ matrix.arch }}-entware.tar.gz youtubeUnblock
+          echo "src-link youtubeUnblock $GITHUB_WORKSPACE" >> feeds.conf
+          cat feeds.conf
+          ./scripts/feeds update youtubeUnblock
+          ./scripts/feeds install -a -p youtubeUnblock
+          echo "CONFIG_PACKAGE_youtubeUnblock=m" | tee -a .config
+          make package/youtubeUnblock/compile V=s
+
+          mv $(find ./bin -type f -name 'youtubeUnblock*.ipk') ./youtubeUnblock-$VERSION-$RELEASE-$SHA-entware-${{ matrix.arch }}.ipk
 
       - name: Upload packages
         if: steps.build.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: youtubeUnblock-entware-${{ matrix.arch }}
-          path: ./**/youtubeUnblock*-entware.tar.gz
+          path: /home/me/Entware/youtubeUnblock*.ipk
           if-no-files-found: error
 
   pre-release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,25 +1,16 @@
-# Tests whether the youtubeUnblock builds properly
-
 name: "youtubeUnblock build test"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: 
+      - main
     paths-ignore:
       - '.editorconfig'
       - '.gitignore'
       - 'LICENSE'
       - 'README.md'
-
-  pull_request:
-    branches: [ "main" ]
-    paths-ignore:
-      - '.editorconfig'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'README.md'
-
   workflow_dispatch:
+  pull_request:
 
 jobs:
   prepare:
@@ -85,103 +76,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - kernel_version: "6.6.52"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.6.52.tar.xz"
-            container_version: "24.04"
-
-          - kernel_version: "5.15.167"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.167.tar.xz"
-            container_version: "24.04"
-
-          - kernel_version: "5.4.284"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.4.284.tar.xz"
-            container_version: "24.04"
-
-          - kernel_version: "4.19.322"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.322.tar.xz"
-            container_version: "24.04"
-
-          - kernel_version: "4.4.302"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.4.302.tar.xz"
-            container_version: "24.04"
-
-          - kernel_version: "3.10.108"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v3.x/linux-3.10.108.tar.xz"
-            container_version: "16.04"
-          
-          - kernel_version: "3.0.101"
-            source: "https://cdn.kernel.org/pub/linux/kernel/v3.x/linux-3.0.101.tar.xz"
-            container_version: "14.04"
+        kernel_version:
+          - 6.6.52
+          - 5.15.167
+          - 5.4.284
+          - 4.19.322
+          - 4.4.302
+          - 3.10.108
+          - 3.0.101
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Restore builder from cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/builder.tar
-          key: builder-${{ matrix.kernel_version }}
-
-      - name: Load builder from cache
-        if: steps.cache-restore.outputs.cache-hit == 'true'
-        run: |
-          docker import - builder < ~/builder.tar
-
-      - name: Prepare build env
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          mkdir ~/linux
-          pwd
-          ls /
-          ls ~
-
-      - name: Obtain kernel
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          cd ~/linux
-          wget ${{ matrix.source }} -O kernel.tar.xz -q
-          tar -xf kernel.tar.xz
-          rm -f kernel.tar.xz
-          /bin/bash -c "mv linux-* linux"
-          ls
-          ls linux
-
-      - name: Install docker
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          cd ~/linux
-          docker pull ubuntu:${{ matrix.container_version }}
-          docker container create --name ubu_builder -w / ubuntu:${{ matrix.container_version }} tail -f /dev/null
-          docker container start ubu_builder
-          docker container exec ubu_builder bash -c "apt update && apt install -y build-essential flex bc bison libelf-dev elfutils libssl-dev"
-          docker cp ./linux ubu_builder:/linux
-
-      - name: Build kernel
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          cd ~/linux
-          docker container exec -w /linux ubu_builder bash -c 'make defconfig'
-          docker container exec -w /linux ubu_builder bash -c 'make -j $(nproc)'
-
-      - name: Export container
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          cd ~/linux
-          docker container kill ubu_builder
-          docker container export ubu_builder > ubu_builder.tar
-          docker container rm ubu_builder
-          mv ./ubu_builder.tar ~/builder.tar
-          docker import - builder < ~/builder.tar
-
-      - name: Save kernel image to cache
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: ~/builder.tar
-          key: builder-${{ matrix.kernel_version }}
 
       - name: Build kernel module
         id: build
@@ -190,7 +95,7 @@ jobs:
           SHA: ${{ needs.prepare.outputs.sha }}
         shell: bash
         run: |
-          docker run --rm -v ./:/youtubeUnblock -w /youtubeUnblock builder make kmake KERNEL_BUILDER_MAKEDIR:=/linux
+          docker run --rm -v ./:/youtubeUnblock -w /youtubeUnblock waujito/kernel-bins:${{ matrix.kernel_version }} make kmake KERNEL_BUILDER_MAKEDIR:=/linux
           tar -czvf kmod-youtubeUnblock-$VERSION-$SHA-linux-${{ matrix.kernel_version }}.tar.gz kyoutubeUnblock.ko
 
       - name: Upload artifacts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".github/builder_containers/entware_docker"]
+	path = .github/builder_containers/entware_docker
+	url = https://github.com/Entware/docker.git


### PR DESCRIPTION
Here is no reason to build binaries every time (github actions cache is limited)