### PR TITLE
Различные фиксы

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -72,8 +72,8 @@ static int read_file(const char* filename) {
 		ret = -errno;
 		goto close_file;
 	}
-	fseek(fd, 0, SEEK_SET);
-	if (ret < 0) {
+	ret = fseek(fd, 0, SEEK_SET);
+	if (ret != 0) {
 		ret = -errno;
 		goto close_file;
 	}

--- a/src/args.c
+++ b/src/args.c
@@ -1246,9 +1246,9 @@ int init_section_config(struct section_config_t **section, struct section_config
 #else
 	def_section = malloc(sizeof(struct section_config_t));
 #endif
-	*def_section = (struct section_config_t)default_section_config;
 	if (def_section == NULL)
 		return -ENOMEM;
+	*def_section = (struct section_config_t)default_section_config;
 
 	def_section->prev = prev;
 

--- a/src/args.c
+++ b/src/args.c
@@ -120,10 +120,10 @@ static int parse_sni_domains(struct domains_list **dlist, const char *domains_st
 			unsigned int domain_len = (i - j);
 			const char *domain_startp = domains_str + j;
 			struct domains_list *edomain = malloc(sizeof(struct domains_list));
-			*edomain = (struct domains_list){0};
 			if (edomain == NULL) {
 				return -ENOMEM;
 			}
+			*edomain = (struct domains_list){0};
 
 			edomain->domain_len = domain_len;
 			edomain->domain_name = malloc(domain_len + 1);

--- a/src/args.c
+++ b/src/args.c
@@ -1243,10 +1243,10 @@ int init_section_config(struct section_config_t **section, struct section_config
 	def_section = malloc(sizeof(struct section_config_t));
 #endif
 	*def_section = (struct section_config_t)default_section_config;
-	def_section->prev = prev;
-
-	if (def_section == NULL) 
+	if (def_section == NULL)
 		return -ENOMEM;
+
+	def_section->prev = prev;
 
 	ret = parse_sni_domains(&def_section->sni_domains, default_snistr, sizeof(default_snistr));
 	if (ret < 0) {

--- a/src/args.c
+++ b/src/args.c
@@ -67,7 +67,7 @@ static int read_file(const char* filename) {
 		goto close_file;
 	}
 
-	size_t fsize = ftell(fd);
+	long fsize = ftell(fd);
 	fseek(fd, 0, SEEK_SET);
 	if (ret < 0) {
 		ret = -errno;

--- a/src/args.c
+++ b/src/args.c
@@ -62,7 +62,7 @@ static int read_file(const char* filename) {
 	}
 
 	ret = fseek(fd, 0, SEEK_END);
-	if (ret < 0) {
+	if (ret != 0) {
 		ret = -errno;
 		goto close_file;
 	}

--- a/src/args.c
+++ b/src/args.c
@@ -289,6 +289,9 @@ static int parse_fake_custom_payload(
 		return -EINVAL;
 	}
 	unsigned char *custom_buf = malloc(custom_len);
+	if (custom_buf == NULL) {
+		return -ENOMEM;
+	}
 
 	for (int i = 0; i < custom_len; i++) {
 		ret = sscanf(custom_hex_fake + (i << 1), "%2hhx", custom_buf + i);

--- a/src/args.c
+++ b/src/args.c
@@ -68,6 +68,10 @@ static int read_file(const char* filename) {
 	}
 
 	long fsize = ftell(fd);
+	if (fsize == -1L) {
+		ret = -errno;
+		goto close_file;
+	}
 	fseek(fd, 0, SEEK_SET);
 	if (ret < 0) {
 		ret = -errno;

--- a/src/quic.c
+++ b/src/quic.c
@@ -71,7 +71,7 @@ int quic_check_is_initial(const struct quic_lhdr *qch) {
 	uint32_t qversion;
 	int ret;
 	ret = quic_get_version(&qversion, qch);
-	if (qversion < 0) return 0;
+	if (ret < 0) return 0;
 
 	uint8_t qtype = qch->type;
 

--- a/src/quic_crypto.c
+++ b/src/quic_crypto.c
@@ -82,6 +82,10 @@ int quic_parse_initial_message(
 	ret = quic_parse_data(quic_payload, quic_plen,
 			&qch, &qch_len, &qci, &inpayload, &inplen
 	);
+	if (ret < 0) {
+		lgerror(ret, "quic_parse_data");
+		goto error_nfr;
+	}
 
 	ret = quic_get_version(&qversion, qch);
 	if (ret < 0) {
@@ -117,10 +121,6 @@ int quic_parse_initial_message(
 	}
 
 	quic_header_len = inpayload - quic_payload;
-	if (ret < 0) {
-		lgerror(ret, "quic_parse_data");
-		goto error_nfr;
-	}
 
 	ret = quic_parse_initial_header(inpayload, inplen, &qich);
 	if (ret < 0) {


### PR DESCRIPTION
Кроме изменений, представленных в PR, нашёл ещё несколько странных мест, но не совсем представляю, как их исправить, поэтому просто упомяну их здесь.

- Переменная 'l' никак не изменяется, поэтому `if (l>0)` всегда `true`, так же как и первое условие в `while`.
```C
// src/getopt.c:84-88
	do {
		d = optstring[i], l = 1;
		if (l>0) i+=l; else i++;
	} while (l && d != c);
```

- Надо добавить проверку на `malloc` и `memcpy` и как-то выйти из функции.
```C
// src/youtubeUnblock.c:617-619
        struct dps_t *dpdt = malloc(sizeof(struct dps_t));
	dpdt->pkt = malloc(data_len);
	memcpy(dpdt->pkt, data, data_len);
```

