### PR TITLE
luci-app: add missing 'parse' option to UDP QUIC filter

### DIFF
--- a/luci-app-youtubeUnblock/htdocs/luci-static/resources/view/youtubeUnblock/configuration.js
+++ b/luci-app-youtubeUnblock/htdocs/luci-static/resources/view/youtubeUnblock/configuration.js
@@ -186,11 +186,12 @@ return view.extend({
 		o.default = o.disabled;
 		o.rmempty = false;
 
-		o = s.option(form.ListValue, "udp_filter_quic", _("UDP QUIC filter"), _("Enables QUIC filtering for UDP handler. If disabled, quic won't be processed, if all, all quic initial packets will be handled."));
+		o = s.option(form.ListValue, "udp_filter_quic", _("UDP QUIC filter"), _("Enables QUIC filtering for UDP handler. If disabled, quic won't be processed, if all, all quic initial packets will be handled, if parse, quic initial packets will be decrypted and matched against sni-domains."));
 		o.widget = "radio"
 		o.depends("quic_drop", "0");
 		o.value("disabled", "disabled");
 		o.value("all", "all");
+		o.value("parse", "parse");
 		o.default = "disabled";
 		o.rmempty = false;
 


### PR DESCRIPTION
## Problem

The `youtubeUnblock` binary supports three values for `--udp-filter-quic`: `disabled`, `all`, and `parse` (parse decrypts/parses the QUIC Initial packet and matches the domain against `--sni-domains`, only applying the UDP fake/handling strategy on a match).

The LuCI page (`configuration.js`) only registers `disabled` and `all` as radio options for the `udp_filter_quic` UCI field:

```js
o.value("disabled", "disabled");
o.value("all", "all");
```

If a user sets `udp_filter_quic` to `parse` via UCI/SSH (a fully valid, documented value the daemon accepts and runs with correctly), the LuCI radio widget renders with **no option selected**, since `parse` isn't in its known value list. Because the field also has `o.rmempty = false` and `o.default = "disabled"`, saving the settings page from the UI in this state silently reverts the option back to `disabled` — which switches QUIC handling from "only touch flows matching sni-domains" back to "touch every QUIC initial packet on UDP/443", defeating the purpose of `parse` mode and affecting non-YouTube QUIC traffic (e.g. any other UDP/443 QUIC-based service on the LAN) without the user necessarily noticing why.

## Fix

Add the missing `o.value("parse", "parse")` registration and extend the field description to mention the `parse` behavior, consistent with the existing `disabled`/`all` descriptions and the CLI help text (`--udp-filter-quic={disabled|all|parse}`).

## Testing

Verified against a live OpenWrt 24.10.1 router running `youtubeUnblock 1.3.1~4a223b0-r1` / `luci-app-youtubeUnblock 0.260408.47027` (current stock OpenWrt package feed version, which has the same bug). Confirmed via `uci get` and the running process args that `parse` is accepted and takes effect at the daemon level; this PR only fixes the LuCI-side option list so the web UI reflects that correctly and doesn't clobber the value on Save.